### PR TITLE
Bugfix for objects with null prototype

### DIFF
--- a/esm/jquery-param.es.js
+++ b/esm/jquery-param.es.js
@@ -25,7 +25,7 @@ var param = function (a) {
                         obj[i]
                     );
                 }
-            } else if (String(obj) === '[object Object]') {
+            } else if (Object.prototype.toString.call(obj) === '[object Object]') {
                 for (key in obj) {
                     buildParams(prefix + '[' + key + ']', obj[key]);
                 }

--- a/esm/jquery-param.es.min.js
+++ b/esm/jquery-param.es.min.js
@@ -1,5 +1,5 @@
 /*
  jquery-param (c) KNOWLEDGECODE | MIT
 */
-export default function(h){function d(c,a){var e;if(c)if(Array.isArray(a)){var b=0;for(e=a.length;b<e;b++)d(c+"["+("object"===typeof a[b]&&a[b]?b:"")+"]",a[b])}else if("[object Object]"===String(a))for(b in a)d(c+"["+b+"]",a[b]);else g(c,a);else if(Array.isArray(a))for(b=0,e=a.length;b<e;b++)g(a[b].name,a[b].value);else for(b in a)d(b,a[b]);return f}function g(c,a){a="function"===typeof a?a():a;a=null===a?"":void 0===a?"":a;f[f.length]=encodeURIComponent(c)+"="+encodeURIComponent(a)}var f=
-[];return d("",h).join("&")}
+export default function(h){function d(c,a){var e;if(c)if(Array.isArray(a)){var b=0;for(e=a.length;b<e;b++)d(c+"["+("object"===typeof a[b]&&a[b]?b:"")+"]",a[b])}else if("[object Object]"===Object.prototype.toString.call(a))for(b in a)d(c+"["+b+"]",a[b]);else g(c,a);else if(Array.isArray(a))for(b=0,e=a.length;b<e;b++)g(a[b].name,a[b].value);else for(b in a)d(b,a[b]);return f}function g(c,a){a="function"===typeof a?a():a;a=null===a?"":void 0===a?"":a;f[f.length]=encodeURIComponent(c)+"="+
+encodeURIComponent(a)}var f=[];return d("",h).join("&")}

--- a/jquery-param.js
+++ b/jquery-param.js
@@ -31,7 +31,7 @@
                             obj[i]
                         );
                     }
-                } else if (String(obj) === '[object Object]') {
+                } else if (Object.prototype.toString.call(obj) === '[object Object]') {
                     for (key in obj) {
                         buildParams(prefix + '[' + key + ']', obj[key]);
                     }

--- a/jquery-param.min.js
+++ b/jquery-param.min.js
@@ -2,4 +2,4 @@
  jquery-param (c) KNOWLEDGECODE | MIT
 */
 'use strict';(function(c,d){"object"===typeof exports&&"undefined"!==typeof module?module.exports=d():"function"===typeof define&&define.amd?define(d):(c="undefined"!==typeof globalThis?globalThis:c||self,c.param=d())})(this,function(){return function(c){var d=[],g=function(e,a){a="function"===typeof a?a():a;a=null===a?"":void 0===a?"":a;d[d.length]=encodeURIComponent(e)+"="+encodeURIComponent(a)},f=function(e,a){var c;if(e)if(Array.isArray(a)){var b=0;for(c=a.length;b<c;b++)f(e+"["+("object"===typeof a[b]&&
-a[b]?b:"")+"]",a[b])}else if("[object Object]"===String(a))for(b in a)f(e+"["+b+"]",a[b]);else g(e,a);else if(Array.isArray(a))for(b=0,c=a.length;b<c;b++)g(a[b].name,a[b].value);else for(b in a)f(b,a[b]);return d};return f("",c).join("&")}})
+a[b]?b:"")+"]",a[b])}else if("[object Object]"===Object.prototype.toString.call(a))for(b in a)f(e+"["+b+"]",a[b]);else g(e,a);else if(Array.isArray(a))for(b=0,c=a.length;b<c;b++)g(a[b].name,a[b].value);else for(b in a)f(b,a[b]);return d};return f("",c).join("&")}})

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ var param = function (a) {
                         obj[i]
                     );
                 }
-            } else if (String(obj) === '[object Object]') {
+            } else if (Object.prototype.toString.call(obj) === '[object Object]') {
                 for (key in obj) {
                     buildParams(prefix + '[' + key + ']', obj[key]);
                 }

--- a/test/test.js
+++ b/test/test.js
@@ -852,6 +852,13 @@
             var obj = NaN;
             test(done, obj);
         });
+
+        it('null Prototype', function (done) {
+            var obj = Object.create(null);
+            obj.test = Object.create(null);
+            obj.test.test = 1;
+            test(done, obj);
+        });
     });
 
 }(this));


### PR DESCRIPTION
Nested objects with null prototype would previously fail to be serialized since `String(Object.create(null))` throws a `TypeError`. `$.param` has always handled this fine.